### PR TITLE
Add more options for controlling the facing direction of sprites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 pxt_modules/
+built/

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+pxt_modules/

--- a/docs/facing-direction.md
+++ b/docs/facing-direction.md
@@ -1,0 +1,11 @@
+# facing direction
+
+A direction that a sprite can face. Use with the lock facing direction block
+
+```sig
+characterAnimations._direction(characterAnimations.FacingDirection.Up)
+```
+
+```package
+arcade-character-animations=github:microsoft/arcade-character-animations
+```

--- a/docs/lock-facing-direction.md
+++ b/docs/lock-facing-direction.md
@@ -1,0 +1,19 @@
+# lock facing direction
+
+Locks the direction that the sprite is facing to the specified direction. While locked, the sprite will always be facing that direction regardless of movement or controller input.
+
+```sig
+characterAnimations.lockFacingDirection(
+    sprites.create(img`.`, SpriteKind.Player),
+    characterAnimations.FacingDirection.Up
+)
+```
+
+## Parameters
+
+* **sprite**: the sprite to lock the facing direction of
+* **direction**: the direction to lock the sprite's facing state in
+
+```package
+arcade-character-animations=github:microsoft/arcade-character-animations
+```

--- a/docs/loop-character-animation.md
+++ b/docs/loop-character-animation.md
@@ -352,5 +352,5 @@ controller.moveSprite(thePlayer)
 ```
 
 ```package
-arcade-story=github:microsoft/arcade-character-animations
+arcade-character-animations=github:microsoft/arcade-character-animations
 ```

--- a/docs/matches-rule.md
+++ b/docs/matches-rule.md
@@ -201,5 +201,5 @@ controller.moveSprite(thePlayer)
 ```
 
 ```package
-arcade-story=github:microsoft/arcade-character-animations
+arcade-character-animations=github:microsoft/arcade-character-animations
 ```

--- a/docs/predicate.md
+++ b/docs/predicate.md
@@ -8,3 +8,6 @@ Predicates can be combined to form rules.
 Predicate.NotMoving
 ```
 
+```package
+arcade-character-animations=github:microsoft/arcade-character-animations
+```

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -186,5 +186,5 @@ controller.moveSprite(hero)
 ```
 
 ```package
-arcade-story=github:microsoft/arcade-character-animations
+arcade-character-animations=github:microsoft/arcade-character-animations
 ```

--- a/docs/run-character-animation.md
+++ b/docs/run-character-animation.md
@@ -226,5 +226,5 @@ game.onUpdate(function () {
 ```
 
 ```package
-arcade-story=github:microsoft/arcade-character-animations
+arcade-character-animations=github:microsoft/arcade-character-animations
 ```

--- a/docs/set-character-animations-enabled.md
+++ b/docs/set-character-animations-enabled.md
@@ -275,5 +275,5 @@ let mySprite2 = sprites.create(img`
 ```
 
 ```package
-arcade-story=github:microsoft/arcade-character-animations
+arcade-character-animations=github:microsoft/arcade-character-animations
 ```

--- a/docs/set-character-state.md
+++ b/docs/set-character-state.md
@@ -201,5 +201,5 @@ game.onUpdateInterval(1000, function () {
 ```
 
 ```package
-arcade-story=github:microsoft/arcade-character-animations
+arcade-character-animations=github:microsoft/arcade-character-animations
 ```

--- a/docs/set-controller.md
+++ b/docs/set-controller.md
@@ -1,0 +1,20 @@
+# set controller
+
+Sets the controller that controls this sprite. When enabled, the directional buttons of the controller will set the facing direction of the sprite instead of the velocity and position changes.
+
+```sig
+characterAnimations.setController(
+    sprites.create(img`.`, SpriteKind.Player),
+    false
+)
+```
+
+## Parameters
+
+* **sprite**: the sprite to set the controller state for
+* **enabled**: a boolean indicating if this sprite is controlled by buttons
+* **controller**: an optional parameter that sets which player is controlling the sprite
+
+```package
+arcade-character-animations=github:microsoft/arcade-character-animations
+```

--- a/docs/unlock-facing-direction.md
+++ b/docs/unlock-facing-direction.md
@@ -1,0 +1,15 @@
+# unlock facing direction
+
+Unlocks the facing direction of the specified sprite, allowing it to change based on movement and controller input again. This only has an effect if the facing direction was previously locked.
+
+```sig
+characterAnimations.unlockFacingDirection(sprites.create(img`.`, SpriteKind.Player))
+```
+
+## Parameters
+
+* **sprite**: the sprite to unlock the facing direction of
+
+```package
+arcade-character-animations=github:microsoft/arcade-character-animations
+```

--- a/main.ts
+++ b/main.ts
@@ -44,12 +44,16 @@ namespace characterAnimations {
 
     export enum FacingDirection {
         //% block="up"
+        //% blockIdentity="characterAnimations._direction"
         Up = Predicate.FacingUp,
         //% block="right"
+        //% blockIdentity="characterAnimations._direction"
         Right = Predicate.FacingRight,
         //% block="down"
+        //% blockIdentity="characterAnimations._direction"
         Down = Predicate.FacingDown,
         //% block="left"
+        //% blockIdentity="characterAnimations._direction"
         Left = Predicate.FacingLeft,
     }
 
@@ -785,6 +789,7 @@ namespace characterAnimations {
         if (p2) rule |= p2;
         if (p3) rule |= p3;
         if (p4) rule |= p4;
+        if (p5) rule |= p5;
 
         // Check for invalid rules
         if (

--- a/main.ts
+++ b/main.ts
@@ -699,10 +699,12 @@ namespace characterAnimations {
      * @param controlledBy The controller that controls this sprite. If not specified, player 1 controller is used.
      */
     //% blockId=arcade_character_animation_set_controller
-    //% block="$sprite set facing controlled by buttons $enabled||$controlledBy"
+    //% block="$sprite control facing direction with buttons $enabled||$controlledBy"
     //% sprite.defl=mySprite
     //% sprite.shadow=variables_get
     //% weight=48
+    //% blockGap=8
+    //% group="Facing"
     //% help=github:arcade-character-animations/docs/set-controller
     export function setController(sprite: Sprite, enabled: boolean, controlledBy?: controller.Controller) {
         if (enabled) {
@@ -733,6 +735,7 @@ namespace characterAnimations {
     //% direction.shadow=arcade_character_facing_direction
     //% weight=45
     //% blockGap=8
+    //% group="Facing"
     //% help=github:arcade-character-animations/docs/lock-facing-direction
     export function lockFacingDirection(sprite: Sprite, direction: number) {
         const state = getStateForSprite(sprite, true);
@@ -752,6 +755,7 @@ namespace characterAnimations {
     //% sprite.defl=mySprite
     //% sprite.shadow=variables_get
     //% weight=44
+    //% group="Facing"
     //% help=github:arcade-character-animations/docs/unlock-facing-direction
     export function unlockFacingDirection(sprite: Sprite) {
         const state = getStateForSprite(sprite, false);
@@ -841,6 +845,7 @@ namespace characterAnimations {
     //% blockId=arcade_character_facing_direction block="$direction"
     //% shim=TD_ID
     //% weight=10
+    //% group="Facing"
     //% help=github:arcade-character-animations/docs/facing-direction
     export function _direction(direction: FacingDirection): number {
         return direction;

--- a/main.ts
+++ b/main.ts
@@ -42,6 +42,17 @@ enum Predicate {
 namespace characterAnimations {
     export type Rule = number;
 
+    export enum FacingDirection {
+        //% block="up"
+        Up = Predicate.FacingUp,
+        //% block="right"
+        Right = Predicate.FacingRight,
+        //% block="down"
+        Down = Predicate.FacingDown,
+        //% block="left"
+        Left = Predicate.FacingLeft,
+    }
+
     const FACING = Predicate.FacingUp | Predicate.FacingRight | Predicate.FacingDown | Predicate.FacingLeft;
     const MOVING = Predicate.MovingUp | Predicate.MovingRight | Predicate.MovingDown | Predicate.MovingLeft | Predicate.Moving;
 
@@ -95,6 +106,9 @@ namespace characterAnimations {
         protected frame: number;
 
         protected manualFlags: number;
+
+        protected controller: controller.Controller;
+        protected lockedFacingDirection: number;
 
         constructor(public sprite: Sprite) {
             this.animations = [];
@@ -170,7 +184,7 @@ namespace characterAnimations {
                     state |= (this.lastState & FACING)
                 }
             }
-            else if (this.sprite.x != this.lastX || this.sprite.y != this.lastY) {
+            else if (this.sprite.x != this.lastX || this.sprite.y != this.lastY && (this.lastX != undefined && this.lastY != undefined)) {
                 state |= Predicate.Moving;
 
                 if (this.sprite.x > this.lastX) {
@@ -212,7 +226,48 @@ namespace characterAnimations {
             this.lastX = this.sprite.x;
             this.lastY = this.sprite.y;
 
+            if (this.lockedFacingDirection) {
+                state = (state & ~FACING) | this.lockedFacingDirection;
+            }
+            // If this sprite is controlled by a controller, use that to
+            // determine facing direction
+            else if (this.controller) {
+                let facing = 0;
+                if (this.controller.up.isPressed() && Predicate.FacingUp & this.possibleFacingDirections) {
+                    facing |= Predicate.FacingUp;
+                }
+                else if (this.controller.down.isPressed() && Predicate.FacingDown & this.possibleFacingDirections) {
+                    facing |= Predicate.FacingDown;
+                }
 
+                if (this.controller.left.isPressed() && Predicate.FacingLeft & this.possibleFacingDirections) {
+                    facing |= Predicate.FacingLeft;
+                }
+                else if (this.controller.right.isPressed() && Predicate.FacingRight & this.possibleFacingDirections) {
+                    facing |= Predicate.FacingRight;
+                }
+
+                state &= ~FACING;
+
+                if (facing) {
+                    state |= facing;
+                }
+                else if (this.lastState & FACING) {
+                    state |= (this.lastState & FACING);
+                }
+                else if (this.possibleFacingDirections & Predicate.FacingLeft) {
+                    state |= Predicate.FacingLeft;
+                }
+                else if (this.possibleFacingDirections & Predicate.FacingDown) {
+                    state |= Predicate.FacingDown;
+                }
+                else if (this.possibleFacingDirections & Predicate.FacingUp) {
+                    state |= Predicate.FacingUp;
+                }
+                else if (this.possibleFacingDirections & Predicate.FacingRight) {
+                    state |= Predicate.FacingRight;
+                }
+            }
 
             const newAnimation = this.pickRule(this.manualFlags || state);
             if (newAnimation !== this.current) {
@@ -270,15 +325,29 @@ namespace characterAnimations {
         }
 
         setEnabled(enabled: boolean) {
+            if (this.enabled === enabled) return;
+
             this.enabled = enabled;
-            if (enabled && this.current) {
-                if (this.runningStartFrames) {
-                    this.sprite.setImage(this.current.startFrames[this.frame])
+            if (enabled) {
+                if (this.current) {
+                    if (this.runningStartFrames) {
+                        this.sprite.setImage(this.current.startFrames[this.frame])
+                    }
+                    else {
+                        this.sprite.setImage(this.current.loopFrames[this.frame])
+                    }
                 }
-                else {
-                    this.sprite.setImage(this.current.loopFrames[this.frame])
-                }
+                this.lastX = undefined;
+                this.lastY = undefined;
             }
+        }
+
+        setController(controller: controller.Controller) {
+            this.controller = controller;
+        }
+
+        lockFacingDirection(direction: number) {
+            this.lockedFacingDirection = direction;
         }
 
         setManualFlags(flags: Rule) {
@@ -437,6 +506,7 @@ namespace characterAnimations {
      * If multiple rules are equally specific, the currently executing rule
      * is favored (or one is chosen at random).
      *
+     *
      * @param sprite    the sprite to animate
      * @param frames    the images that make up that animation
      * @param frameInterval the amount of time to spend on each frame in milliseconds
@@ -470,6 +540,7 @@ namespace characterAnimations {
      * If multiple rules are equally specific, the currently executing rule
      * is favored (or one is chosen at random).
      *
+     *
      * @param sprite    the sprite to animate
      * @param frames    the images that make up that animation
      * @param frameInterval the amount of time to spend on each frame in milliseconds
@@ -497,6 +568,7 @@ namespace characterAnimations {
      * Use to check the current state of a sprite. Be careful, sprites
      * will only be facing a direction if they have an animation
      * that uses the one of the facing direction rules (e.g. FacingLeft, FacingUp, etc.).
+     *
      *
      * @param sprite    The sprite to check the state of
      * @param rule      The rule to check
@@ -558,6 +630,7 @@ namespace characterAnimations {
      * This is useful for temporarily turning off animations while
      * another animation plays (e.g. an attack animation)
      *
+     *
      * @param sprite    The sprite to enable/disable animations on
      * @param enabled   True to enable, false to disable
      */
@@ -580,6 +653,7 @@ namespace characterAnimations {
      * effect until you call clear state or set the state to something else.
      * Invalid states (i.e. "moving" and "not moving") are ignored.
      *
+     *
      * @param sprite    The sprite to set the state of
      * @param rule      The state to set on the sprite
      */
@@ -600,6 +674,7 @@ namespace characterAnimations {
      * Clear the current state of the sprite. This will also disable any
      * manually set state and re-enable automatic state tracking.
      *
+     *
      * @param sprite    The sprite to clear the state of
      */
     //% blockId=arcade_character_animation_clear_state
@@ -611,6 +686,78 @@ namespace characterAnimations {
     export function clearCharacterState(sprite: Sprite) {
         const state = getStateForSprite(sprite, false);
         if (state) state.clearState();
+    }
+
+    /**
+     * Sets the controller that controls this sprite. When enabled, the directional
+     * buttons of the controller will set the facing direction of the sprite instead
+     * of the velocity and position changes.
+     *
+     *
+     * @param sprite The sprite to set the controller for
+     * @param enabled True if this sprite is controlled by a controller, false otherwise
+     * @param controlledBy The controller that controls this sprite. If not specified, player 1 controller is used.
+     */
+    //% blockId=arcade_character_animation_set_controller
+    //% block="$sprite set facing controlled by buttons $enabled||$controlledBy"
+    //% sprite.defl=mySprite
+    //% sprite.shadow=variables_get
+    //% weight=48
+    //% help=github:arcade-character-animations/docs/set-controller
+    export function setController(sprite: Sprite, enabled: boolean, controlledBy?: controller.Controller) {
+        if (enabled) {
+            if (!controlledBy) {
+                controlledBy = controller.player1;
+            }
+        }
+        else {
+            controlledBy = null;
+        }
+
+        const state = getStateForSprite(sprite, true);
+        state.setController(controlledBy);
+    }
+
+    /**
+     * Locks the direction that the sprite is facing to the specified direction. While locked,
+     * the sprite will always be facing that direction regardless of movement or controller input.
+     *
+     *
+     * @param sprite The sprite to lock the facing direction for
+     * @param direction The direction to lock the sprite's facing direction to
+     */
+    //% blockId=arcade_character_animation_lock_facing_direction
+    //% block="$sprite lock facing direction to $direction"
+    //% sprite.defl=mySprite
+    //% sprite.shadow=variables_get
+    //% direction.shadow=arcade_character_facing_direction
+    //% weight=45
+    //% blockGap=8
+    //% help=github:arcade-character-animations/docs/lock-facing-direction
+    export function lockFacingDirection(sprite: Sprite, direction: number) {
+        const state = getStateForSprite(sprite, true);
+        state.lockFacingDirection(direction);
+    }
+
+    /**
+     * Unlocks the facing direction of the specified sprite, allowing it to change
+     * based on movement and controller input again. This only has an effect if the
+     * facing direction was previously locked.
+     *
+     *
+     * @param sprite The sprite to unlock the facing direction for
+     */
+    //% blockId=arcade_character_animation_unlock_facing_direction
+    //% block="$sprite unlock facing direction"
+    //% sprite.defl=mySprite
+    //% sprite.shadow=variables_get
+    //% weight=44
+    //% help=github:arcade-character-animations/docs/unlock-facing-direction
+    export function unlockFacingDirection(sprite: Sprite) {
+        const state = getStateForSprite(sprite, false);
+        if (state) {
+            state.lockFacingDirection(0);
+        }
     }
 
     /**
@@ -686,5 +833,16 @@ namespace characterAnimations {
     //% help=github:arcade-character-animations/docs/predicate
     export function _predicate(predicate: Predicate): number {
         return predicate
+    }
+
+    /**
+     * A direction a sprite can face
+     */
+    //% blockId=arcade_character_facing_direction block="$direction"
+    //% shim=TD_ID
+    //% weight=10
+    //% help=github:arcade-character-animations/docs/facing-direction
+    export function _direction(direction: FacingDirection): number {
+        return direction;
     }
 }

--- a/pxt.json
+++ b/pxt.json
@@ -15,7 +15,11 @@
         "docs/run-character-animation.md",
         "docs/set-character-animations-enabled.md",
         "docs/set-character-state.md",
-        "docs/rule.md"
+        "docs/rule.md",
+        "docs/set-controller.md",
+        "docs/lock-facing-direction.md",
+        "docs/facing-direction.md",
+        "docs/unlock-facing-direction.md"
     ],
     "testFiles": [
         "test.ts"

--- a/test.ts
+++ b/test.ts
@@ -89,7 +89,7 @@ mySprite,
     . . . . . . . . . f f f . . . .
     `],
 500,
-characterAnimations.rule(Predicate.MovingDown)
+characterAnimations.rule(Predicate.Moving, Predicate.FacingDown)
 )
 characterAnimations.loopFrames(
 mySprite,
@@ -163,7 +163,7 @@ mySprite,
     . . . . . . . . . f f f . . . .
     `],
 500,
-characterAnimations.rule(Predicate.MovingUp)
+characterAnimations.rule(Predicate.Moving, Predicate.FacingUp)
 )
 characterAnimations.loopFrames(
 mySprite,
@@ -237,7 +237,7 @@ mySprite,
     . . . . . . . f f f . . . . . .
     `],
 500,
-characterAnimations.rule(Predicate.MovingRight)
+characterAnimations.rule(Predicate.Moving, Predicate.FacingRight)
 )
 characterAnimations.loopFrames(
 mySprite,
@@ -311,7 +311,7 @@ mySprite,
     . . . f f f . . . f f . . . . .
     `],
 500,
-characterAnimations.rule(Predicate.MovingLeft)
+characterAnimations.rule(Predicate.Moving, Predicate.FacingLeft)
 )
 characterAnimations.loopFrames(
 mySprite,
@@ -690,3 +690,20 @@ mySprite,
 characterAnimations.rule(Predicate.FacingUp, Predicate.NotMoving)
 )
 
+let flip = false;
+
+// characterAnimations.setController(mySprite, true)
+controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
+    flip = !flip;
+
+    if (flip) {
+        characterAnimations.lockFacingDirection(mySprite, characterAnimations.FacingDirection.Left)
+    } else {
+        characterAnimations.unlockFacingDirection(mySprite);
+    }
+})
+game.onUpdate(function () {
+    mySprite.x ++;
+})
+
+mySprite.setFlag(SpriteFlag.StayInScreen, true)


### PR DESCRIPTION
adds a few new blocks for better control over the facing direction of sprites when using character animations:

<img width="332" height="154" alt="image" src="https://github.com/user-attachments/assets/5c471259-82a3-4233-8200-d108c326100c" />

the first block there lets you set that a sprite's direction should always be controlled by button presses. this is generally true for player sprites; you never want them to switch direction unless the player presses a button. the optional parameter on this block lets you set the controller for the sprite (for multiplayer). the other two blocks are similar to the "set state" block except they only lock the direction of the sprite. useful for things like knockback when a character takes damage.

a few other random fixes for things i noticed while poking around:
* added an extra line of space between jsdoc description and params because that's what the makecode parser looks for
* fixed the package annotation in all of the docs pages
* fixed movement glitches when re-enabling character animations after they have been disabled (that's the last x/y undefined check)
* added cli files to gitignore
* fixed the fifth predicate in the rule block being ignored